### PR TITLE
feat: remove edge prop from SsrSite

### DIFF
--- a/packages/sst/src/config.ts
+++ b/packages/sst/src/config.ts
@@ -218,10 +218,10 @@ export namespace Config {
     );
     const siteDataEdge = siteData
       .filter((c) => c.data.mode === "deployed")
-      .filter((c) => c.data.edge);
+      .filter((c) => c.data.deploymentStrategy === "edge");
     const siteDataRegional = siteData
       .filter((c) => c.data.mode === "deployed")
-      .filter((c) => !c.data.edge);
+      .filter((c) => c.data.deploymentStrategy !== "regional");
     const regionalSiteArns = siteData.map((s) => s.data.server);
     const functionData = Object.values(metadata)
       .flat()

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -109,6 +109,7 @@ export class AstroSite extends SsrSite {
     };
 
     const plan: Plan = {
+      deploymentStrategy: buildMeta.deploymentStrategy,
       cloudFrontFunctions: {
         serverCfFunction: {
           constructId: "CloudFrontFunction",

--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -94,7 +94,7 @@ export class AstroSite extends SsrSite {
   }
 
   protected plan() {
-    const { path: sitePath, edge } = this.props;
+    const { path: sitePath } = this.props;
 
     const buildMeta = AstroSite.getBuildMeta(
       join(sitePath, "dist", BUILD_META_FILE_NAME)
@@ -102,18 +102,6 @@ export class AstroSite extends SsrSite {
 
     const isStatic = buildMeta.outputMode === "static";
     const isEdge = buildMeta.deploymentStrategy === "edge";
-
-    if (isEdge && !edge) {
-      throw new Error(
-        `Conflict between edge deployment strategy and 'edge' option. Set the 'edge' option to true.`
-      );
-    }
-
-    if (!isEdge && edge === true) {
-      throw new Error(
-        `Conflict between regional deployment strategy and 'edge' option. Either remove the 'edge' option or set it to false.`
-      );
-    }
 
     const serverConfig = {
       description: "Server handler for Astro",

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -250,6 +250,7 @@ export class NextjsSite extends SsrSite {
     });
     this.removeSourcemaps();
     return this.validatePlan({
+      deploymentStrategy: edge ? "edge" : "regional",
       cloudFrontFunctions: {
         serverCfFunction: {
           constructId: "CloudFrontFunction",

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -60,6 +60,11 @@ export interface NextjsSiteProps extends Omit<SsrSiteProps, "nodejs"> {
    * ```
    */
   logging?: "combined" | "per-route";
+  /**
+   * The SSR function is deployed to Lambda in a single region. Alternatively, you can enable this option to deploy to Lambda@Edge.
+   * @default false
+   */
+  edge?: boolean;
   imageOptimization?: {
     /**
      * The amount of memory in MB allocated for image optimization function.

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -67,6 +67,7 @@ export class RemixSite extends SsrSite {
     };
 
     return this.validatePlan({
+      deploymentStrategy: edge ? "edge" : "regional",
       cloudFrontFunctions: {
         serverCfFunction: {
           constructId: "CloudFrontFunction",

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -3,9 +3,10 @@ import url from "url";
 import path from "path";
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
-import { SsrSite } from "./SsrSite.js";
+import { SsrSite, SsrSiteNormalizedProps, SsrSiteProps } from "./SsrSite.js";
 import { VisibleError } from "../error.js";
 import { useWarning } from "./util/warning.js";
+import { Construct } from "constructs";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
@@ -16,6 +17,16 @@ type RemixConfig = {
   serverPlatform: string;
   server?: string;
 };
+
+export interface RemixSiteProps extends SsrSiteProps {
+  /**
+   * The SSR function is deployed to Lambda in a single region. Alternatively, you can enable this option to deploy to Lambda@Edge.
+   * @default false
+   */
+  edge?: boolean;
+}
+
+type RemixSiteNormalizedProps = RemixSiteProps & SsrSiteNormalizedProps;
 
 /**
  * The `RemixSite` construct is a higher level CDK construct that makes it easy to create a Remix app.
@@ -31,6 +42,12 @@ type RemixConfig = {
  * ```
  */
 export class RemixSite extends SsrSite {
+  declare props: RemixSiteNormalizedProps;
+
+  constructor(scope: Construct, id: string, props?: RemixSiteProps) {
+    super(scope, id, props);
+  }
+
   protected plan() {
     const { path: sitePath, edge } = this.props;
 

--- a/packages/sst/src/constructs/SolidStartSite.ts
+++ b/packages/sst/src/constructs/SolidStartSite.ts
@@ -1,6 +1,17 @@
 import fs from "fs";
 import path from "path";
-import { SsrSite } from "./SsrSite.js";
+import { SsrSite, SsrSiteNormalizedProps, SsrSiteProps } from "./SsrSite.js";
+import { Construct } from "constructs";
+
+export interface SolidStartSiteProps extends SsrSiteProps {
+  /**
+   * The SSR function is deployed to Lambda in a single region. Alternatively, you can enable this option to deploy to Lambda@Edge.
+   * @default false
+   */
+  edge?: boolean;
+}
+
+type SolidStartSiteNormalizedProps = SolidStartSiteProps & SsrSiteNormalizedProps;
 
 /**
  * The `SolidStartSite` construct is a higher level CDK construct that makes it easy to create a SolidStart app.
@@ -14,6 +25,12 @@ import { SsrSite } from "./SsrSite.js";
  * ```
  */
 export class SolidStartSite extends SsrSite {
+  declare props: SolidStartSiteNormalizedProps;
+
+  constructor(scope: Construct, id: string, props?: SolidStartSiteProps) {
+    super(scope, id, props);
+  }
+
   protected plan() {
     const { path: sitePath, edge } = this.props;
     const serverConfig = {

--- a/packages/sst/src/constructs/SolidStartSite.ts
+++ b/packages/sst/src/constructs/SolidStartSite.ts
@@ -39,6 +39,7 @@ export class SolidStartSite extends SsrSite {
     };
 
     return this.validatePlan({
+      deploymentStrategy: edge ? "edge" : "regional",
       cloudFrontFunctions: {
         serverCfFunction: {
           constructId: "CloudFrontFunction",

--- a/packages/sst/src/constructs/SvelteKitSite.ts
+++ b/packages/sst/src/constructs/SvelteKitSite.ts
@@ -1,6 +1,17 @@
 import fs from "fs";
 import path from "path";
-import { SsrSite } from "./SsrSite.js";
+import { SsrSite, SsrSiteNormalizedProps, SsrSiteProps } from "./SsrSite.js";
+import { Construct } from "constructs";
+
+export interface SvelteKitSiteProps extends SsrSiteProps {
+  /**
+   * The SSR function is deployed to Lambda in a single region. Alternatively, you can enable this option to deploy to Lambda@Edge.
+   * @default false
+   */
+  edge?: boolean;
+}
+
+type SvelteKitSiteNormalizedProps = SvelteKitSiteProps & SsrSiteNormalizedProps;
 
 /**
  * The `SvelteKitSite` construct is a higher level CDK construct that makes it easy to create a SvelteKit app.
@@ -14,7 +25,12 @@ import { SsrSite } from "./SsrSite.js";
  * ```
  */
 export class SvelteKitSite extends SsrSite {
+  declare props: SvelteKitSiteNormalizedProps;
   protected typesPath = "src";
+
+  constructor(scope: Construct, id: string, props?: SvelteKitSiteProps) {
+    super(scope, id, props);
+  }
 
   protected plan() {
     const { path: sitePath, edge } = this.props;

--- a/packages/sst/src/constructs/SvelteKitSite.ts
+++ b/packages/sst/src/constructs/SvelteKitSite.ts
@@ -63,6 +63,7 @@ export class SvelteKitSite extends SsrSite {
     };
 
     return this.validatePlan({
+      deploymentStrategy: edge ? "edge" : "regional",
       buildId: JSON.parse(
         fs
           .readFileSync(path.join(sitePath, clientDir, "_app/version.json"))


### PR DESCRIPTION
This PR removes the `edge` prop as a default prop on the `SsrSite` construct and makes it an integration specific prop for all other SSR modules. In place of the `prop.edge` specifier, there is now a construct level `deploymentStrategy` property which is set from the results of `plan()`.

This implementation is a bit ugly. I'm open to ideas...